### PR TITLE
fix(format): update to latest format command for bugfixes

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,7 @@
       "dependencies": {
         "@nestjs/common": "^9.4.0",
         "@sunbeams/eslint-config": "0.1.0",
-        "@sunbeams/format": "^0.2.0",
+        "@sunbeams/format": "^0.2.1",
         "eslint": "^8.39.0",
         "nest-commander": "^3.6.2"
       },
@@ -466,9 +466,9 @@
       }
     },
     "node_modules/@sunbeams/format": {
-      "version": "0.2.0",
-      "resolved": "https://registry.npmjs.org/@sunbeams/format/-/format-0.2.0.tgz",
-      "integrity": "sha512-vdM47iskeHC/kGLN1laITRxRHewB1TOb/hBP5Yk+49YOfMHVsxkmoy8bkPBoFSsAlxTxdmqhCylfBJ7gQkT6kg==",
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/@sunbeams/format/-/format-0.2.1.tgz",
+      "integrity": "sha512-i7U+X45fCpkbWuKUhN9hRMb7SL3VHIp7ji93+AOWJDXYH4rrOQnCOpLIoSQgvXXkg9EXwu9+OnVaPNELiDyH2A==",
       "dependencies": {
         "@nestjs/common": "^9.4.0",
         "nest-commander": "^3.6.2",

--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
   "dependencies": {
     "@nestjs/common": "^9.4.0",
     "@sunbeams/eslint-config": "0.1.0",
-    "@sunbeams/format": "^0.2.0",
+    "@sunbeams/format": "^0.2.1",
     "eslint": "^8.39.0",
     "nest-commander": "^3.6.2"
   },

--- a/src/commands/format.command.ts
+++ b/src/commands/format.command.ts
@@ -4,22 +4,12 @@
  * file, You can obtain one at https://mozilla.org/MPL/2.0/.
  */
 
-import { Command, CommandRunner, Option } from 'nest-commander'
-import { FormatRunner } from '@sunbeams/format'
-import type { FormatRunnerFlagValues } from '@sunbeams/format'
+import { Command } from 'nest-commander'
+import { FormatCommand as FormatCommandBase, FormatRunner } from '@sunbeams/format'
 
 @Command({
   name: 'format',
   aliases: ['fmt'],
   ...FormatRunner.Metadata
 })
-export class FormatCommand extends CommandRunner {
-  async run(args: string[], options: FormatRunnerFlagValues): Promise<void> {
-    await new FormatRunner({ path: args[0], ...options }).run()
-  }
-
-  @Option(FormatRunner.Flags.Check)
-  check(value: boolean): boolean {
-    return value
-  }
-}
+export class FormatCommand extends FormatCommandBase {}


### PR DESCRIPTION
This should allow format to work properly in ci environments and when not used under an npm script. Yay!