### PR TITLE
refactor(lint): use npx instead of straight eslint

### DIFF
--- a/src/commands/lint/lint.runner.ts
+++ b/src/commands/lint/lint.runner.ts
@@ -38,10 +38,10 @@ export class LintRunner {
     const config = ['--config', configPath]
     const color = '--color'
 
-    const args = [directory, ...exclude, ...config, color]
+    const args = ['eslint', directory, ...exclude, ...config, color]
 
     if (fix === true) args.push('--fix')
 
-    await exec('eslint', args)
+    await exec('npx', args)
   }
 }


### PR DESCRIPTION
Rely on some of npms magic to resolve where the eslint command lives.

Closes #31